### PR TITLE
Simplify release process

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 1.4.019
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
+
+[bumpversion:file:src/iota/__init__.py]
+search = iota_version = "{current_version}"
+replace = iota_version = "{new_version}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,18 @@ jobs:
       script:
          - .travis/run-flake8
       if: type = pull_request
+
+# Assuming you have installed the travis-ci CLI tool, after you
+# create the Github repo and add it to Travis, run the
+# following command to finish PyPI deployment setup:
+# $ travis encrypt --add deploy.password
+deploy:
+  provider: pypi
+  distributions: sdist bdist_wheel
+  user: mgerstel
+  password:
+    secure: fAaDQ0VZZU/vqgSS3rNkoyqTHg5oGAd77BbjB/FpYP3WXp8kYhesNPTwDDzqgmf4Lb24tD5T6h7akv/97F2L0oBxG2ALABuZ3b/h2UGUZVmKhqP96/dcuh6mgf+02r1hx/wVxWsLbgN7V5VE0Ast7PbD3AHfuG5birsksRXTrfsCZD6pR4NmY7ALxcdVLc3sgB6+BAmglksLzGtO2SCuxnzqXsLtgM65HYrBLwpSKuStXb0JG12aNtNmAIttqATycneQi5V4NXlVkyPvBkvqKM6pQREYBf4dixe7W9wtYFcp5AyuZJjINRaVtpB8CMYsqk5LkkT6s2zuWaSn2JkSNzPdM5RtCogo37T4+GQmv6Ho4nlsft/ZxV8jyXx4j/3HupkcmF+x8PIi2cTBOlI9rCPOHG2vSQiXJGUB4a+3mez4pq8MhV2HyFxva+NgCcC8LHNim+/CQBod/4WMxztcHgqMDl7swvk0uMNZfmNhjwHqDiZKQe2+JpFqx+jD9KRBkmakekojjwMS26iULQfdcj9QakgbP177/lsOrSVgXxKfj2TVid6UIkWwLi7zUi6u+rixTAp3rBPLVkkmpwtSIRF16qf1m5LJKRSeYlx6qX7tvCCxbxXhTQJTgjGS97b36gTuj/yz36kgaJIovDNdP64dEkZSgiCxqnUOXRTN7LE=
+  on:
+    tags: true
+    repo: ssrl-px/iota
+    python: 3.7


### PR DESCRIPTION
This sets up [bumpversion](https://pypi.org/project/bump2version/) for preparing releases
and Travis to publish releases.

The documentation below should probably go somewhere (shamelessly copied from https://raw.githubusercontent.com/DiamondLightSource/ispyb-api/master/RELEASE.md)

## How to prepare a release

To prepare an IOTA release you need to install the package bump2version

```bash
pip install bump2version # or conda install / libtbx.pip install, depending on your environment
```

and then, in the repository directory, run one of the following

```bash
# assuming current version is 1.2.3
bumpversion patch  # release version 1.2.4
bumpversion minor  # release version 1.3.0
bumpversion major  # release version 2.0.0
```

This automatically creates a release commit and a release tag.
You then need to push those to the Github repository
```bash
git push; git push --tags
```

The release is then created by Travis and uploaded directly onto pypi.
