### PR TITLE
Break the DIALS/xfel circular dependency

### DIFF
--- a/src/iota/base/processor.py
+++ b/src/iota/base/processor.py
@@ -684,7 +684,7 @@ class Processor(object):
 
     def construct_frame(self, integrated, exeriments):
         # Construct frame
-        from xfel.command_line.frame_extractor import ConstructFrame
+        from serialtbx.util.construct_frame import ConstructFrame
 
         self.frame = ConstructFrame(integrated, experiments[0]).make_frame()
         self.frame["pixel_size"] = experiments[0].detector[0].get_pixel_size()[0]

--- a/src/iota/processing/processing.py
+++ b/src/iota/processing/processing.py
@@ -242,7 +242,7 @@ class IOTAImageProcessor(Processor):
         """
 
         # Construct frame
-        from xfel.command_line.frame_extractor import ConstructFrame
+        from serialtbx.util.construct_frame import ConstructFrame
 
         self.frame = ConstructFrame(integrated, experiments[0]).make_frame()
         self.frame["pixel_size"] = experiments[0].detector[0].get_pixel_size()[0]


### PR DESCRIPTION
DIALS and dxtbx have had dependencies on cctbx_project/xfel, and vice versa. This PR is one of 8 that will break the cyclic dependency.

For more detail, see cctbx/cctbx_project#872